### PR TITLE
Fix: Trim values to ensure valid URLs are created

### DIFF
--- a/src/github_url_builder/github_url_builder.ts
+++ b/src/github_url_builder/github_url_builder.ts
@@ -2,6 +2,6 @@ import { GitRemote } from "../git/git_remote";
 
 export class GithubUrlBuilder {
   buildUrl(gitRemote: GitRemote, branch: string, filePath: string): string {
-    return `https://github.com/${gitRemote.owner}/${gitRemote.name}/blob/${branch}/${filePath}`;
+    return `https://github.com/${gitRemote.owner.trim()}/${gitRemote.name.trim()}/blob/${branch}/${filePath}`;
   }
 }


### PR DESCRIPTION
`gitRemote.owner` and `gitRemote.name` can in some circumstances have a line break at the end of them, which generates a broken URL. This just guards against that outcome.